### PR TITLE
Add a quickstart guide using kubectl

### DIFF
--- a/docs/getting-started/create-first-cluster/using_kubectl.md
+++ b/docs/getting-started/create-first-cluster/using_kubectl.md
@@ -1,7 +1,58 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
-# Using kubectl
+# Create & Import Your First Cluster Using kubectl
 
-This section needs to be filled out.
+This section will guide you through creating your first cluster and importing it into Rancher Manager using kubectl.
+
+## Prerequisites
+
+- Rancher Manager cluster with Rancher Turtles installed
+- Cluster API providers installed for your scenario - we'll be using the Docker infrastructure and Kubeadm bootstrap/control plane providers in these instructions
+- **clusterctl** CLI - see the [releases](https://github.com/kubernetes-sigs/cluster-api/releases)
+
+## Create Your Cluster Definition
+
+To generate the YAML for the cluster, do the following (assuming the Docker infrastructure provider is being used):
+
+1. Open a terminal and run the following:
+
+```bash
+export CONTROL_PLANE_MACHINE_COUNT=1
+export WORKER_MACHINE_COUNT=1
+export KUBERNETES_VERSION=v1.26.4
+
+clusterctl generate cluster cluster1 \
+--from https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-kubeadm.yaml \
+> cluster1.yaml
+```
+
+2. View **cluster1.yaml** to ensure there are no tokens. You can make any changes you want as well.
+
+> The Cluster API quickstart guide contains more detail. Read the steps related to this section [here](https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers).
+
+3. Create the cluster using kubectl
+
+```bash
+kubectl create -f cluster1.yaml
+```
+
+## Mark Namespace or Cluster for Auto-Import
+
+To automatically import a CAPI cluster into Rancher Manager, there are 2 options:
+
+1. Label a namespace so all clusters contained in it are imported.
+2. Label an individual cluster definition so that it's imported.
+
+Labeling a namespace:
+
+```bash
+kubectl label namespace default cluster-api.cattle.io/rancher-auto-import=true
+```
+
+Labeling an individual cluster definition:
+
+```bash
+kubectl label cluster.cluster.x-k8s.io cluster1 cluster-api.cattle.io/rancher-auto-import=true
+```


### PR DESCRIPTION
Add a quickstart guide using kubectl, it's similar to the fleet one https://github.com/rancher-sandbox/rancher-turtles-docs/pull/19 with differences in steps to committing the import label.

Fixes: https://github.com/rancher-sandbox/rancher-turtles-docs/issues/6