### PR TITLE
docs: minor updates on internal links and notes

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -108,9 +108,9 @@ If you need help at any stage of your work, please don't hesitate to ask!
 1. Push your changes to the branch on your fork and submit a pull request to the original repository
 against the `main` branch.
 
-    ```bash
-    git push <remote-name> <feature-name>
-    ```
+```bash
+git push <remote-name> <feature-name>
+```
 1. Submit a pull request.
     1. All code PR must be labeled with one of
         - ⚠️ (`:warning:`, major or breaking changes)
@@ -193,7 +193,9 @@ _See below for [how issues are prioritized](#prioritizing-issues)_.
 
 ## ADRs (Architectural Decision Records)
 
-**Note:** please feel free to skip [this](#adrs-architectural-decision-records) and [sub-section](#process) below, since they are only relevant to the [rancher-turtles](https://github.com/rancher-sandbox/rancher-turtles) repository.
+:::note
+Please feel free to skip [this](#adrs-architectural-decision-records) and [sub-section](#process) below, since they are only relevant to the [rancher-turtles](https://github.com/rancher-sandbox/rancher-turtles) repository.
+:::
 
 Any impactful decisions to the architecture, design, development and behaviour
 of rancher-turtles must be recorded in the form of an [ADR](https://engineering.atspotify.com/2020/04/14/when-should-i-write-an-architecture-decision-record/).

--- a/docs/getting-started/create-first-cluster/using_fleet.md
+++ b/docs/getting-started/create-first-cluster/using_fleet.md
@@ -14,11 +14,13 @@ This section will guide you through creating your first cluster and importing it
 
 ## Create your cluster definition
 
-The **clusterctl** CLI can be used to generate the YAML for a cluster. When you run `clusterctl generate cluster` command is run, it will connect to the management cluster to see what infrastructure providers have been installed. Also, it will take care of replacing any tokens in the chosen template (a.k.a flavour) with values from environment variables.
+The **clusterctl** CLI can be used to generate the YAML for a cluster. When you run `clusterctl generate cluster`, it will connect to the management cluster to see what infrastructure providers have been installed. Also, it will take care of replacing any tokens in the chosen template (a.k.a flavour) with values from environment variables.
 
 Alternatively, you can craft the YAML for your cluster manually. If you decide to do this then you can use the **templates** that infrastructure providers publish as part of their releases. For example, the AWS provider [publishes files](https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/tag/v2.2.1) prefixed with **cluster-template** that can be used as a base. You will need to replace any tokens yourself or by using clusterctl (e.g. `clusterctl generate cluster test1 --from https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/download/v2.2.1/cluster-template-eks.yaml > cluster.yaml`).
 
-> This guide does not use ClusterClass. Templates that use ClusterClass will require that the experimental feature be enabled.
+:::note
+This guide does not use ClusterClass. Templates that use ClusterClass will require that the experimental feature be enabled.
+:::
 
 To generate the YAML for the cluster do the following (assuming the Docker infrastructure provider is being used):
 
@@ -36,7 +38,9 @@ clusterctl generate cluster cluster1 \
 
 2. View **cluster1.yaml** to ensure there are no tokens. You can make any changes you want as well.
 
-> The Cluster API quickstart guide contains more detail. Read the steps related to this section [here](https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers).
+:::tip
+The Cluster API quickstart guide contains more detail. Read the steps related to this section [here](https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers).
+:::
 
 ## Create your repo for Fleet
 
@@ -51,7 +55,9 @@ namespace: default
 
 5. Commit the changes
 
-> The **fleet.yaml** is used to specify configuration options for fleet (see [docs](https://fleet.rancher.io/ref-fleet-yaml) for further details). In this instance its declaring that the cluster definitions should be added to the **default** namespace
+:::note
+The **fleet.yaml** is used to specify configuration options for fleet (see [docs](https://fleet.rancher.io/ref-fleet-yaml) for further details). In this instance its declaring that the cluster definitions should be added to the **default** namespace
+:::
 
 After the described steps there will be a repository created structure similar to the example: <https://github.com/rancher-sandbox/rancher-turtles-fleet-example>
 

--- a/docs/getting-started/install_capi_operator.md
+++ b/docs/getting-started/install_capi_operator.md
@@ -34,7 +34,10 @@ helm install capi-operator capi-operator/cluster-api-operator
 	--set cert-manager.enabled=true
 	--timeout 90s --wait # Core Cluster API with kubeadm bootstrap and control plane providers will also be installed
 ```
-*Note: `cert-manager` is a hard requirement for `CAPI` and `Cluster API Operator`*
+
+:::note
+`cert-manager` is a hard requirement for `CAPI` and `Cluster API Operator`*
+:::
 
 To provide additional environment variables, enable feature gates, or supply cloud credentials, similar to `clusterctl` [common provider](https://cluster-api.sigs.k8s.io/user/quick-start#initialization-for-common-providers), variables secret with `name` and a `namespace` of the secret could be specified for the `Cluster API Operator` as shown below.
 
@@ -71,4 +74,6 @@ helm install ... --set infrastructure="docker:v1.4.6;azure:v1.4.6"
 
 The `infrastructure` flag is set to `docker:v1.4.6;azure:v1.4.6`, representing the desired provider names. This means that the `Cluster API Operator` will install and manage multiple providers, `Docker` and `Azure` respectively, with versions `v1.4.6` specified in this example.
 
+:::tip
 For more fine-grained control of the providers and other components installed with CAPI, see the [Add the infrastructure provider](../tasks/capi-operator/add_infrastructure_provider.md) section.
+:::

--- a/docs/getting-started/install_turtles_operator.md
+++ b/docs/getting-started/install_turtles_operator.md
@@ -8,8 +8,6 @@ This section walks through different installation options for the Rancher Turtle
 
 ### Install Rancher Turtles Operator with `Cluster API Operator` as a Helm dependency
 
-*Note: this section will be extended with additional details later*
-
 A `rancher-turtles` chart repository should be added first:
 
 ```bash
@@ -90,7 +88,9 @@ A `Rancher Turtles` requires a connection to the `Rancher Manager` cluster. This
 
 1. Installing it in the same cluster as the `Rancher Manager`.
 
-*Note: In the future, we will support different deployment topologies*
+:::tip
+For information on deployment options, refer to [Deployment Scenarios](../reference-guides/architecture/deployment)
+:::
 
 The recommended path of installation for the operator is by using `Helm`. To install it in the cluster, a chart repository should be added first:
 

--- a/docs/tasks/capi-operator/installing_core_provider.md
+++ b/docs/tasks/capi-operator/installing_core_provider.md
@@ -20,4 +20,6 @@ spec:
   version: v1.4.6
 ```
 
-**Note:** Only one CoreProvider can be installed at the same time on a single cluster.
+:::note
+Only one CoreProvider can be installed at the same time on a single cluster.
+:::


### PR DESCRIPTION
### Description

Some minor aesthetic fixes adding [Docusaurus `notes` and `tips` boxes](https://docusaurus.io/docs/next/markdown-features/admonitions) and  add link to recently merged page `Deployment Scenarios`.