### PR TITLE
docs: update getting started guide after validation

### DIFF
--- a/docs/getting-started/install_turtles_operator.md
+++ b/docs/getting-started/install_turtles_operator.md
@@ -18,12 +18,18 @@ helm repo update
 To install `Cluster API Operator` as a dependency to the `Rancher Turtles`, a minimum set of additional helm flags should be specified:
 
 ```bash
-helm install rancher-turtles turtles/rancher-turtles
+helm install rancher-turtles turtles/rancher-turtles --version <chart-version>
     -n rancher-turtles-system
     --dependency-update
     --create-namespace --wait
     --timeout 180s
 ```
+
+:::note
+- If `cert-manager` is already available in the cluster, you can disable its installation as a Rancher Turtles dependency to avoid conflicts:
+`--set cluster-api-operator.cert-manager.enabled=false`
+- For a list of Rancher Turtles versions, refer to [Releases page](https://github.com/rancher-sandbox/rancher-turtles/releases).
+:::
 
 This is the basic, recommended configuration, which manages the creation of a secret containing the required feature flags (`CLUSTER_TOPOLOGY`, `EXP_CLUSTER_RESOURCE_SET` and `EXP_MACHINE_POOL` enabled) in the core provider namespace.
 
@@ -104,7 +110,7 @@ helm repo update
 and then it can be installed into the `rancher-turtles-system` namespace with:
 
 ```bash
-helm install rancher-turtles turtles/rancher-turtles
+helm install rancher-turtles turtles/rancher-turtles --version <chart-version>
     -n rancher-turtles-system
     --set cluster-api-operator.enabled=false
     --set cluster-api-operator.cluster-api.enabled=false

--- a/docs/getting-started/rancher.md
+++ b/docs/getting-started/rancher.md
@@ -6,23 +6,32 @@ sidebar_position: 2
 
 ## Installing Rancher
 
-To install `Rancher` in an existing or new Kubernetes cluster, you can use the following steps:
+*If you're already running Rancher, you can skip this section and jump to [Setting up Rancher for Rancher Turtles](#setting-up-rancher-for-rancher-turtles).*
 
-1. First, make sure to follow one of the official [installation guides](https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-and-upgrade) for `Rancher`.
-2. When installing `Rancher` using the `helm` command, use the `--set` option to specify the `features` parameter. For the `embedded-cluster-api` feature, set the value to `false` to disable it.
-3. Use the `--version` option to specify the version of `Rancher` you want to install. In this case, use the [recommended](../getting-started/intro.md#prerequisites) `Rancher` version for `Rancher Turtles`.
+Helm is the recommended way to install `Rancher` in an existing or new Kubernetes cluster.
 
-Here's the complete command to install `Rancher` with the `embedded-cluster-api` feature disabled. Replace `<rancher-hostname>` with the actual hostname of your `Rancher` server:
+:::tip
+Make sure to follow one of the official [installation guides](https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-and-upgrade) for Rancher.
+:::
+
+Here's a minimal configuration example of a command to install `Rancher`:
 
 ```bash
-helm install rancher rancher-stable/rancher --set features=embedded-cluster-api=false --set hostname=<rancher-hostname> --set version=<rancher-version> --set namespace=cattle-system --create-namespace --wait
+helm install rancher rancher-stable/rancher
+    --namespace cattle-system
+    --create-namespace
+    --set hostname=<rancher-hostname>
+    --version <rancher-version>
+    --wait
 ```
 
-## Existing Rancher installation
+Replace `<rancher-hostname>` with the actual hostname of your `Rancher` server and use the `--version` option to specify the version of `Rancher` you want to install. In this case, use the [recommended](../getting-started/intro.md#prerequisites) `Rancher` version for `Rancher Turtles`.
 
-To install `Rancher Turtles` in an existing `Rancher` cluster, follow these steps:
+## Setting up Rancher for Rancher Turtles
 
-1. Create a `feature.yaml` file, with `embedded-cluster-api` feature disabled:
+Before installing Rancher Turtles in your Rancher environment, the `embedded-cluster-api` functionality must be disabled:
+
+1. Create a `feature.yaml` file, with `embedded-cluster-api` set to false:
 ```yaml title="feature.yaml"
 apiVersion: management.cattle.io/v3
 kind: Feature
@@ -35,3 +44,5 @@ spec:
 ```bash
 kubectl apply -f feature.yaml
 ```
+
+Your Rancher installation is now ready to install and use Rancher Turtles! 🎉


### PR DESCRIPTION
### Descrition

After validating [Getting Started](https://docs.rancher-turtles.com/docs/category/getting-started), we identified a few improvements:
- If disabling `embedded-cluster-api` during Rancher installation, the cluster must be `clusterctl` initialized to successfully install Rancher. If it is not, it will fail. The problem with this approach is that `clusterctl init` will create namespaces that we're then creating again in the `rancher-turtles` Helm chart. Hence, we decided to document a "standard" installation of Rancher (with `embedded-cluster-api` enabled) and then disabling the feature manually. This fixes the problem with the namespaces.
- Installing `rancher-turtles` after Rancher means that `cert-manager` is already installed in the cluster. If no flag is passed to `rancher-turtles` Helm chart, it'll try to install `cert-manager` as a dependency. It is now recommended to disable this.
- The Helm chart is published with the release workflow but the version must be specified in the `helm install` command.