### PR TITLE
Fix rancher-turtles-docs GitHub repo reference

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -79,7 +79,7 @@ const config = {
           },
           { to: '/blog', label: 'Blog', position: 'left' },
           {
-            href: 'https://github.com/rancher-sandbox/rancher-turtles-doc',
+            href: 'https://github.com/rancher-sandbox/rancher-turtles-docs',
             label: 'GitHub',
             position: 'right',
           },


### PR DESCRIPTION
Currently GitHub link in the book refers to the wrong URL:
![image](https://github.com/rancher-sandbox/rancher-turtles-docs/assets/40443040/1fe87c52-c09b-4e4c-9e99-962a888cd8d3)

