### PR TITLE
docs: add webhook deletion instructions

### DIFF
--- a/docs/getting-started/create-first-cluster/using_fleet.md
+++ b/docs/getting-started/create-first-cluster/using_fleet.md
@@ -9,7 +9,7 @@ This section will guide you through creating your first cluster and importing it
 ## Prerequisites
 
 - Rancher Manager cluster with Rancher Turtles installed
-- Cluster API providers installed for your scenario - we'll be using the Docker infrastructure and Kubeadm bootstrap/controlplane providers in these instructions
+- Cluster API providers installed for your scenario - we'll be using the Docker infrastructure and Kubeadm bootstrap/control plane providers in these instructions - see [Initialization for common providers](https://cluster-api.sigs.k8s.io/user/quick-start.html#initialization-for-common-providers)
 - **clusterctl** CLI - see the [releases](https://github.com/kubernetes-sigs/cluster-api/releases)
 
 ## Create your cluster definition

--- a/docs/getting-started/create-first-cluster/using_kubectl.md
+++ b/docs/getting-started/create-first-cluster/using_kubectl.md
@@ -9,7 +9,7 @@ This section will guide you through creating your first cluster and importing it
 ## Prerequisites
 
 - Rancher Manager cluster with Rancher Turtles installed
-- Cluster API providers installed for your scenario - we'll be using the Docker infrastructure and Kubeadm bootstrap/control plane providers in these instructions
+- Cluster API providers installed for your scenario - we'll be using the Docker infrastructure and Kubeadm bootstrap/control plane providers in these instructions - see [Initialization for common providers](https://cluster-api.sigs.k8s.io/user/quick-start.html#initialization-for-common-providers)
 - **clusterctl** CLI - see the [releases](https://github.com/kubernetes-sigs/cluster-api/releases)
 
 ## Create Your Cluster Definition

--- a/docs/getting-started/rancher.md
+++ b/docs/getting-started/rancher.md
@@ -29,7 +29,11 @@ Replace `<rancher-hostname>` with the actual hostname of your `Rancher` server a
 
 ## Setting up Rancher for Rancher Turtles
 
-Before installing Rancher Turtles in your Rancher environment, the `embedded-cluster-api` functionality must be disabled:
+Before installing Rancher Turtles in your Rancher environment, Rancher's `embedded-cluster-api` functionality must be disabled. This includes also cleaning up Rancher specific webhooks that otherwise would conflict with CAPI ones.
+
+:::note**Caution!**
+Follow these instructions in the order below. Altering the execution sequence may cause errors due to inconsistent resource configuration.
+:::
 
 1. Create a `feature.yaml` file, with `embedded-cluster-api` set to false:
 ```yaml title="feature.yaml"
@@ -43,6 +47,11 @@ spec:
 2. Use `kubectl` to apply the `feature.yaml` file to the cluster:
 ```bash
 kubectl apply -f feature.yaml
+```
+3. Delete the remaining Rancher webhooks to avoid conflicts with CAPI.
+```bash
+kubectl delete mutatingwebhookconfigurations.admissionregistration.k8s.io mutating-webhook-configuration
+kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io validating-webhook-configuration
 ```
 
 Your Rancher installation is now ready to install and use Rancher Turtles! 🎉


### PR DESCRIPTION
### Description

This is part of issue https://github.com/rancher-sandbox/rancher-turtles/issues/185.

While we work on a permanent robust solution, we update the docs to add an extra instruction to delete Rancher webhooks that are not removed when disabling the embedded capi functionality in an existing Rancher Manager. This also adds a link to the CAPI documentation on initializing infrastructure providers that I think can be useful for users.