### PR TITLE
docs: remove rancher pre-installation requirements

### DIFF
--- a/docs/getting-started/install_turtles_operator.md
+++ b/docs/getting-started/install_turtles_operator.md
@@ -6,6 +6,14 @@ sidebar_position: 4
 
 This section walks through different installation options for the Rancher Turtles Operator.
 
+:::info
+Before [installing Rancher Turtles](#install-rancher-turtles-operator-with-cluster-api-operator-as-a-helm-dependency) in your Rancher environment, Rancher's `embedded-cluster-api` functionality must be disabled. This includes also cleaning up Rancher-specific webhooks that otherwise would conflict with CAPI ones.
+
+To simplify setting up Rancher for installing Rancher Turtles, the official Rancher Turtles Helm chart includes a `pre-install` hook that applies these changes, making it transparent to the end user:
+- Disable the `embedded-cluster-api` feature in Rancher.
+- Delete the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks that are no longer needed.
+:::
+
 ### Install Rancher Turtles Operator with `Cluster API Operator` as a Helm dependency
 
 A `rancher-turtles` chart repository should be added first:

--- a/docs/getting-started/rancher.md
+++ b/docs/getting-started/rancher.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 ## Installing Rancher
 
-*If you're already running Rancher, you can skip this section and jump to [Setting up Rancher for Rancher Turtles](#setting-up-rancher-for-rancher-turtles).*
+*If you're already running Rancher, you can skip this section and jump to [Install Rancher Turtles Operator](./install_turtles_operator.md).*
 
 Helm is the recommended way to install `Rancher` in an existing or new Kubernetes cluster.
 
@@ -27,31 +27,4 @@ helm install rancher rancher-stable/rancher
 
 Replace `<rancher-hostname>` with the actual hostname of your `Rancher` server and use the `--version` option to specify the version of `Rancher` you want to install. In this case, use the [recommended](../getting-started/intro.md#prerequisites) `Rancher` version for `Rancher Turtles`.
 
-## Setting up Rancher for Rancher Turtles
-
-Before installing Rancher Turtles in your Rancher environment, Rancher's `embedded-cluster-api` functionality must be disabled. This includes also cleaning up Rancher specific webhooks that otherwise would conflict with CAPI ones.
-
-:::note**Caution!**
-Follow these instructions in the order below. Altering the execution sequence may cause errors due to inconsistent resource configuration.
-:::
-
-1. Create a `feature.yaml` file, with `embedded-cluster-api` set to false:
-```yaml title="feature.yaml"
-apiVersion: management.cattle.io/v3
-kind: Feature
-metadata:
-  name: embedded-cluster-api
-spec:
-  value: false
-```
-2. Use `kubectl` to apply the `feature.yaml` file to the cluster:
-```bash
-kubectl apply -f feature.yaml
-```
-3. Delete the remaining Rancher webhooks to avoid conflicts with CAPI.
-```bash
-kubectl delete mutatingwebhookconfigurations.admissionregistration.k8s.io mutating-webhook-configuration
-kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io validating-webhook-configuration
-```
-
-Your Rancher installation is now ready to install and use Rancher Turtles! 🎉
+You are now ready to install and use Rancher Turtles! 🎉


### PR DESCRIPTION
#### Issue #43 

### Description

With the introduction of the [pre-install Helm hook](https://github.com/rancher-sandbox/rancher-turtles/pull/192) users no longer have to disable embedded CAPI and delete Rancher's remaining webhooks (this is now handled by `helm install`).

### What this PR does

This PR adds the following updates:
- Removes pre-installation steps from the Rancher configuration for installing Rancher Turtles.
- Adds an informative section to `Install Rancher Turtles Operator` with the actions applied during the pre-install phase while installing the Rancher Turtles Helm chart.