### PR TITLE
✨Docs versioning, automated

### DIFF
--- a/.github/workflows/version-publish.yaml
+++ b/.github/workflows/version-publish.yaml
@@ -1,0 +1,34 @@
+name: Publish new docs version
+
+on:
+  push:
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+env:
+  TAG: ${{ github.ref_name }}
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Prepare the tag
+        run: echo "TAG=${TAG#v}" >> $GITHUB_ENV
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Create a new version
+        run: yarn docusaurus docs:version ${{ env.TAG }}
+      - uses: EndBug/add-and-commit@v9
+        with:
+          message: 'Add docs version ${{ env.TAG }}'
+          push: false
+      - name: Push changes
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          branch: main
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ $ yarn build
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
 
+### Versioning
+
+This project follows docusaurus [versioning](https://docusaurus.io/docs/versioning#configuring-versioning-behavior) guidelines, including the process of [archiving](https://docusaurus.io/docs/versioning#keep-the-number-of-versions-small) the old versions.
+
 ### Deployment
 
 Using SSH:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -40,6 +40,12 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
+          versions: {
+            current: {
+              label: 'Next 🚧',
+              badge: false,
+            },
+          },
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
@@ -79,7 +85,12 @@ const config = {
           },
           { to: '/blog', label: 'Blog', position: 'left' },
           {
-            href: 'https://github.com/rancher-sandbox/rancher-turtles-docs',
+            type: 'docsVersionDropdown',
+            position: 'right',
+            dropdownActiveClassDisabled: true,
+          },
+          {
+            href: 'https://github.com/rancher-sandbox/rancher-turtles-doc',
             label: 'GitHub',
             position: 'right',
           },


### PR DESCRIPTION
There are 2 possible approaches to versioning:
- Manual versioning flow. Meaning - you run `yarn docusaurus docs:version v<tag>` and create a PR with updated content. The new version will appear on the page.
- Tag driven flow: someone pushes a new tag to the docs repository. The first step is executed, all changes are committed and pushed to the main page directly. Alternatively, a PR is opened by and automation and then it is getting reviewed (even though there is nothing essential to review, and PR may diverge over time if would not get merged).

This PR implements the second option, which directly pushes into the main branch. 

Fixes: #39