### PR TITLE
fix: broken link to github repo

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -90,7 +90,7 @@ const config = {
             dropdownActiveClassDisabled: true,
           },
           {
-            href: 'https://github.com/rancher-sandbox/rancher-turtles-doc',
+            href: 'https://github.com/rancher-sandbox/rancher-turtles-docs',
             label: 'GitHub',
             position: 'right',
           },


### PR DESCRIPTION
### Description

Just fixing a typo in link to `rancher-turtles-docs` GitHub repository before tagging the initial version of the docs.