### PR TITLE
docs: add reference guide section for chart values

### DIFF
--- a/docs/getting-started/install_turtles_operator.md
+++ b/docs/getting-started/install_turtles_operator.md
@@ -58,38 +58,9 @@ stringData:
   CUSTOM_ENV_VAR: "false"
 ```
 
-Any values passed to `helm` with the `cluster-api-operator` key will be passed along to the `Cluster API Operator` project. A full set of available values for the `Cluster API Operator` can be found in the operator [values.yaml](https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/hack/charts/cluster-api-operator/values.yaml).
-
-Currently the available set of values for the `cluster-api-operator` setup in the `rancher-turtles`:
-
-```yaml
-cluster-api-operator:
-  enabled: true # indicates if CAPI operator should be installed (default: true)
-  cert-manager:
-    enabled: true # indicates if cert-manager should be installed (default: true)
-  cluster-api:
-    enabled: true # indicates if core CAPI controllers should be installed (default: true)
-    version: v1.4.6 # version of CAPI to install (default: v1.4.6)
-    configSecret:
-      name: "" # (provide only if using a user-managed secret) name of the config secret to use for core CAPI controllers, used by the CAPI operator. See [CAPI operator](https://github.com/kubernetes-sigs/cluster-api-operator/tree/main/docs#installing-azure-infrastructure-provider) docs for more details.
-      namespace: "" # (provide only if using a user-managed secret) namespace of the config secret to use for core CAPI controllers, used by the CAPI operator.
-      defaultName: "capi-env-variables" # default name for the automatically created secret.
-    core:
-      namespace: capi-system
-      fetchConfig: # (only required for airgapped environments)
-        url: ""  # url to fetch config from, used by the CAPI operator. See [CAPI operator](https://github.com/kubernetes-sigs/cluster-api-operator/tree/main/docs#provider-spec) docs for more details.
-        selector: ""  # selector to use for fetching config, used by the CAPI operator.
-    kubeadmBootstrap:
-      namespace: capi-kubeadm-bootstrap-system
-      fetchConfig:
-        url: ""
-        selector: ""
-    kubeadmControlPlane:
-      namespace: capi-kubeadm-control-plane-system
-      fetchConfig:
-        url: ""
-        selector: ""
-```
+:::info
+For detailed information on the values supported by the chart and their usage, refer to [Helm chart options](../reference-guides/rancher-turtles-chart/values)
+:::
 
 ### Install Rancher Turtles Operator without `Cluster API Operator` as a Helm dependency
 

--- a/docs/reference-guides/rancher-turtles-chart/values.md
+++ b/docs/reference-guides/rancher-turtles-chart/values.md
@@ -1,0 +1,66 @@
+---
+sidebar_position: 0
+---
+
+# Chart configuration
+
+:::tip
+For the up-to-date content of `values.yaml` source file, refer to the [Rancher Turtles repository](https://github.com/rancher-sandbox/rancher-turtles).
+:::
+
+## Rancher Turtles values
+
+When installing Rancher Turtles Operator using the official Helm chart, it is possible to configure a number of feature flags. This is a comprehensive list of the available values and their usage:
+
+```yaml
+rancherTurtles:
+  features:
+    embedded-capi: # this is a rancher functionality that is not compatible with rancher-turtles
+      disabled: true # indicates that embedded-capi must be disabled during installation (default: true)
+    rancher-webhook: # an existing rancher installation keeps rancher webhooks after disabling embedded-capi      
+      cleanup: true # indicates that the remaining rancher webhooks be removed (default: true)
+      kubectlImage: rancher/kubectl # indicates the image to use for webhook cleanup (default: rancher/kubectl)
+    rancher-kubeconfigs: # with capi 1.5.0 and greater, secrets for kubeconfigs must contain a specific label. See https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/providers/migrations/v1.4-to-v1.5.md#other
+      label: true # indicates that the label will be added (default: true)
+```
+
+The list has been truncated to show only the configurable feature flags. Other fields with the `rancherTurtles` key are automatically set when a chart is released.
+
+## Cluster API Operator values
+
+Any values passed to `helm` with the `cluster-api-operator` key will be passed along to the `Cluster API Operator` project.
+
+:::tip
+A full set of available values for the `Cluster API Operator` can be found in the operator [values.yaml](https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/hack/charts/cluster-api-operator/values.yaml).
+:::
+
+Currently the available set of values for the `cluster-api-operator` setup in the `rancher-turtles`:
+
+```yaml
+cluster-api-operator:
+  enabled: true # indicates if CAPI operator should be installed (default: true)
+  cert-manager:
+    enabled: true # indicates if cert-manager should be installed (default: true)
+  cluster-api:
+    enabled: true # indicates if core CAPI controllers should be installed (default: true)
+    version: v1.4.6 # version of CAPI to install (default: v1.4.6)
+    configSecret:
+      name: "" # (provide only if using a user-managed secret) name of the config secret to use for core CAPI controllers, used by the CAPI operator. See https://github.com/kubernetes-sigs/cluster-api-operator/tree/main/docs#installing-azure-infrastructure-provider docs for more details.
+      namespace: "" # (provide only if using a user-managed secret) namespace of the config secret to use for core CAPI controllers, used by the CAPI operator.
+      defaultName: "capi-env-variables" # default name for the automatically created secret.
+    core:
+      namespace: capi-system
+      fetchConfig: # (only required for airgapped environments)
+        url: ""  # url to fetch config from, used by the CAPI operator. See https://github.com/kubernetes-sigs/cluster-api-operator/tree/main/docs#provider-spec docs for more details.
+        selector: ""  # selector to use for fetching config, used by the CAPI operator.
+    kubeadmBootstrap:
+      namespace: capi-kubeadm-bootstrap-system
+      fetchConfig:
+        url: ""
+        selector: ""
+    kubeadmControlPlane:
+      namespace: capi-kubeadm-control-plane-system
+      fetchConfig:
+        url: ""
+        selector: ""
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -57,6 +57,7 @@ const sidebars = {
             'reference-guides/architecture/deployment',
           ]
         },
+      'reference-guides/rancher-turtles-chart/values',
       ],
     },
     {


### PR DESCRIPTION
**What this PR does**

As we add [values](https://github.com/rancher-sandbox/rancher-turtles/blob/main/charts/rancher-turtles/values.yaml) to the Rancher Turtles Helm chart, we need to document the available flags and their usage.

This PR adds a new section under `Reference Guides` focused on the Rancher Turtles Helm chart values and their meaning. It also moves the list of `cluster-api-operator` values that can be passed to this new section and adds a docusaurus [admonitions](https://docusaurus.io/docs/next/markdown-features/admonitions) with a link to the specific reference guide.

**Which issue(s) this PR fixes**:

Fixes #47 