### PR TITLE
Update references to upstream CAPI Operator documentation

### DIFF
--- a/docs/tasks/capi-operator/add_infrastructure_provider.md
+++ b/docs/tasks/capi-operator/add_infrastructure_provider.md
@@ -2,19 +2,13 @@
 sidebar_position: 3
 ---
 
-# Add Infrastructure Provider
-
-This section describes how an infrastructure provider such as `Azure` could be added using `Cluster API Operator`.
-
-### Installing Azure Infrastructure Provider
-
-Next, install [Azure Infrastructure Provider](https://capz.sigs.k8s.io/). Before that ensure that `capz-system` namespace exists.
-
-Since the provider requires variables to be set, create a secret containing them in the same namespace as the provider. It is also recommended to include a `github-token` in the secret. This token is used to fetch the provider repository, and it is required for the provider to be installed. The operator may exceed the rate limit of the GitHub API without the token. Like [clusterctl](https://cluster-api.sigs.k8s.io/clusterctl/overview.html?highlight=github_token#avoiding-github-rate-limiting), the token needs only the `repo` scope.
-
-## Option 1: CAPIProvider resource
+# Installing Azure Infrastructure Provider using CAPIProvider resource
 
 This section describes how to install the Azure `InfrastructureProvider` via `CAPIProvider`, which is responsible for managing Cluster API Azure CRDs and the Cluster API Azure controller.
+
+:::note
+This section describes how to install the raw Azure `InfrastructureProvider`, which is responsible for managing the Cluster API Azure CRDs and the Cluster API Azure controller. The detailed configuration steps are described in the [official](https://cluster-api-operator.sigs.k8s.io/03_topics/03_basic-cluster-api-provider-installation/02_installing-capz#installing-azure-infrastructure-provider) CAPI Operator documentation.
+:::
 
 *Example:*
 
@@ -42,45 +36,8 @@ spec:
   version: v1.9.3
   type: infrastructure # required
   configSecret:
-    name: azure-variables # This will additionally poulate the default set of feature gates for the provider
+    name: azure-variables # This will additionally populate the default set of feature gates for the provider inside the secret
 ```
-
-## Option 2: Raw InfrastructureProvider resource
-
-This section describes how to install the Azure `InfrastructureProvider`, which is responsible for managing the Cluster API Azure CRDs and the Cluster API Azure controller.
-
-*Example:*
-
-```yaml
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: azure-variables
-  namespace: capz-system
-type: Opaque
-stringData:
-  AZURE_CLIENT_ID_B64: Zm9vCg==
-  AZURE_CLIENT_SECRET_B64: Zm9vCg==
-  AZURE_SUBSCRIPTION_ID_B64: Zm9vCg==
-  AZURE_TENANT_ID_B64: Zm9vCg==
-  github-token: ghp_fff
----
-apiVersion: operator.cluster.x-k8s.io/v1alpha2
-kind: InfrastructureProvider
-metadata:
- name: azure
- namespace: capz-system
-spec:
- version: v1.9.3
- configSecret:
-   name: azure-variables
-
-```
-:::tip
-**There are known issues when provisioning clusters using CAPZ v1.12.0.**
-We recommend using version v1.11.5.
-:::
 
 ### Deleting providers
 

--- a/docs/tasks/capi-operator/basic_cluster_api_provider_installation.md
+++ b/docs/tasks/capi-operator/basic_cluster_api_provider_installation.md
@@ -4,13 +4,4 @@ sidebar_position: 1
 
 # Basic Cluster API Provider Installation
 
-This section describes the basic process of installing `CAPI` providers using the operator. The `Cluster API Operator` manages five types of provider objects:
-
-- `CoreProvider`
-- `BootstrapProvider`
-- `ControlPlaneProvider`
-- `InfrastructureProvider`
-- `AddonProvider`
-- `IPAMProvider`
-
-Please note that this example provides a basic configuration of Azure Infrastructure provider for getting started. More detailed examples and CRD descriptions are provided in the `Cluster API Operator` [documentation](https://github.com/kubernetes-sigs/cluster-api-operator/tree/main/docs#readme)
+This section describes the basic process of installing `CAPI` providers using the operator and a basic configuration of Azure Infrastructure provider. For [section](https://cluster-api-operator.sigs.k8s.io/03_topics/03_basic-cluster-api-provider-installation/#basic-cluster-api-provider-installation) details please refer to official CAPI Operator documentation.

--- a/docs/tasks/capi-operator/capiprovider_resource.md
+++ b/docs/tasks/capi-operator/capiprovider_resource.md
@@ -8,6 +8,8 @@ The `CAPIProvider` resource allows managing Cluster API Operator manifests in a 
 
 `CAPIProvider` follows a GitOps model - the spec fields are declarative user inputs. The controller only updates status.
 
+Every field provided by the upstream CAPI Operator resource for the desired `spec.type` is also available in the spec of the `CAPIProvider` resouce. Feel free to refer to upstream configuration [guides](https://cluster-api-operator.sigs.k8s.io/03_topics/02_configuration/) for advanced scenarios.
+
 [ARD](https://github.com/rancher-sandbox/rancher-turtles/blob/main/docs/adr/0007-rancher-turtles-public-api.md)
 
 ## Usage
@@ -53,10 +55,11 @@ The key fields in the `CAPIProvider` spec are:
 - `features` - Enabled provider features
 - `variables` - Variables is a map of environment variables to add to the content of the `configSecret`
 
-Full documentation on the CAPIProvider resource - [here](https://doc.crds.dev/github.com/rancher-sandbox/rancher-turtles/turtles-capi.cattle.io/CAPIProvider/v1alpha1@v0.4.0).
+Full documentation on the CAPIProvider resource - [here](https://doc.crds.dev/github.com/rancher-sandbox/rancher-turtles/turtles-capi.cattle.io/CAPIProvider/v1alpha1@v0.5.0).
 
 ## Deletion
 
 When a `CAPIProvider` resource is deleted, the kubernetes garbage collection will clean up all the generated provider resources that it owns. This includes:
+
 - Cluster API Operator resource instance
 - Secret referenced by the `configSecret`

--- a/docs/tasks/capi-operator/installing_core_provider.md
+++ b/docs/tasks/capi-operator/installing_core_provider.md
@@ -2,17 +2,15 @@
 sidebar_position: 4
 ---
 
-# Installing the CoreProvider
-
-Any existing namespace could be utilized for providers in the Kubernetes cluster. However, before creating a provider object, make sure the specified namespace has been created. In the example below, we use the `capi-system` namespace. To create this namespace through either the Command Line Interface (CLI) by running `kubectl create namespace capi-system`, or the declarative approach described in the [official Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/namespaces-walkthrough/#create-new-namespaces) could be used.
-
-:::note
-Only one CoreProvider can be installed at the same time on a single cluster.
-:::
-
-## Option 1: CAPIProvider resource
+# Installing the CoreProvider using CAPIProvider resource
 
 This section describes how to install the `CoreProvider` via `CAPIProvider`, which is responsible for managing the Cluster API CRDs and the Cluster API controller.
+
+:::note
+Please refer to installing Core Provider [section](https://cluster-api-operator.sigs.k8s.io/03_topics/03_basic-cluster-api-provider-installation/01_installing-core-provider#installing-the-coreprovider) in CAPI Operator docs for additional details on raw `CoreProvider` resource installation.
+
+Only one CoreProvider can be installed at the same time on a single cluster.
+:::
 
 *Example:*
 
@@ -25,20 +23,4 @@ metadata:
 spec:
   version: v1.4.6
   type: core # required
-```
-
-## Option 2: CoreProvider resource
-
-This section describes how to install the `CoreProvider`, which is responsible for managing the Cluster API CRDs and the Cluster API controller.
-
-*Example:*
-
-```yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha2
-kind: CoreProvider
-metadata:
-  name: cluster-api
-  namespace: capi-system
-spec:
-  version: v1.4.6
 ```


### PR DESCRIPTION
We need to remove stale parts of the documentation related to raw CAPI Operator operations, as the user is expected to use CAPIProvider resource in all cases. This adds a reference to the upstream docs where possible, to keep the users in sync with changes.