### PR TITLE
Fixes the typo

### DIFF
--- a/docs/next/modules/en/pages/developer/development.adoc
+++ b/docs/next/modules/en/pages/developer/development.adoc
@@ -20,7 +20,7 @@
     "debug": {
         "turtles": {
             "continue": true,
-            "port": 40000
+            "port": 40000,
             "insecure_skip_verify": "true"
         }
     }

--- a/docs/v0.17/modules/en/pages/developer/development.adoc
+++ b/docs/v0.17/modules/en/pages/developer/development.adoc
@@ -20,7 +20,7 @@
     "debug": {
         "turtles": {
             "continue": true,
-            "port": 40000
+            "port": 40000,
             "insecure_skip_verify": "true"
         }
     }

--- a/docs/v0.18/modules/en/pages/developer/development.adoc
+++ b/docs/v0.18/modules/en/pages/developer/development.adoc
@@ -20,7 +20,7 @@
     "debug": {
         "turtles": {
             "continue": true,
-            "port": 40000
+            "port": 40000,
             "insecure_skip_verify": "true"
         }
     }

--- a/docs/v0.19/modules/en/pages/developer/development.adoc
+++ b/docs/v0.19/modules/en/pages/developer/development.adoc
@@ -20,7 +20,7 @@
     "debug": {
         "turtles": {
             "continue": true,
-            "port": 40000
+            "port": 40000,
             "insecure_skip_verify": "true"
         }
     }

--- a/docs/v0.20/modules/en/pages/developer/development.adoc
+++ b/docs/v0.20/modules/en/pages/developer/development.adoc
@@ -20,7 +20,7 @@
     "debug": {
         "turtles": {
             "continue": true,
-            "port": 40000
+            "port": 40000,
             "insecure_skip_verify": "true"
         }
     }


### PR DESCRIPTION
This commit fixes the missing `,` in tilt_settings.yaml, for v0.17, v0.18, v0.19 & v0.20 modules.