### PR TITLE
Adding Google Tag Manager Analytics

### DIFF
--- a/turtles-supplemental-files/partials/body.hbs
+++ b/turtles-supplemental-files/partials/body.hbs
@@ -1,0 +1,9 @@
+<div class="body">
+{{!-- Begin Google Tag Manager Override --}}
+<noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-57KS2MW"height="0" width="0" style="display:none;visibility:hidden"></iframe>
+</noscript>
+{{!-- End Google Tag Manager Override --}}
+{{> nav}}
+{{> main}}
+</div>

--- a/turtles-supplemental-files/partials/head-scripts.hbs
+++ b/turtles-supplemental-files/partials/head-scripts.hbs
@@ -1,0 +1,10 @@
+{{#with site.keys.googleAnalytics}}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{this}}"></script>
+<script>function gtag(){dataLayer.push(arguments)};window.dataLayer=window.dataLayer||[];gtag('js',new Date());gtag('config','{{this}}')</script>
+{{/with}}
+{{!-- Begin Google Tag Manager Override --}}
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-57KS2MW');</script>
+{{!-- End Google Tag Manager Override --}}
+{{!--
+<script>var uiRootPath = '{{{uiRootPath}}}'</script>
+--}}


### PR DESCRIPTION
Adding GTM override encoding to enable GA4 tracking on community docs. The tag is added to the header and body front matter of content pages for aggregating data.