### PR TITLE
Add OneTrust to ensure compliance

### DIFF
--- a/turtles-supplemental-files/partials/head-scripts.hbs
+++ b/turtles-supplemental-files/partials/head-scripts.hbs
@@ -1,3 +1,9 @@
+{{!-- OneTrust Cookies Consent Notice start --}}
+<script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="0f98beb0-fc4c-417d-a42e-564e2cae42d2" ></script>
+<script type="text/javascript">
+function OptanonWrapper() { }
+</script>
+{{!-- OneTrust Cookies Consent Notice end --}}
 {{#with site.keys.googleAnalytics}}
 <script async src="https://www.googletagmanager.com/gtag/js?id={{this}}"></script>
 <script>function gtag(){dataLayer.push(arguments)};window.dataLayer=window.dataLayer||[];gtag('js',new Date());gtag('config','{{this}}')</script>


### PR DESCRIPTION
Requested by SD-192521. 

> Since we have Google Analytics on the domain, it is necessary to implement OneTrust to ensure compliance.

<img width="1514" height="147" alt="onetrust-1" src="https://github.com/user-attachments/assets/41a6ec35-2989-4f96-b310-5299657f3e10" />

<img width="475" height="888" alt="onetrust-2" src="https://github.com/user-attachments/assets/2ba6ee4f-bda9-41cb-8458-5c3e27a3c468" />
