### PR TITLE
docs: Rename `rancher-turtles-system` ns to `cattle-turtles-system` ns

### DIFF
--- a/docs/next/modules/en/pages/operator/manual.adoc
+++ b/docs/next/modules/en/pages/operator/manual.adoc
@@ -44,7 +44,7 @@ Once the Helm repository has been added and updated locally, you can proceed to 
 [source,bash]
 ----
 helm install rancher-turtles turtles/rancher-turtles --version v0.24.0 \
-    -n rancher-turtles-system \
+    -n cattle-turtles-system \
     --dependency-update \
     --create-namespace --wait \
     --timeout 180s
@@ -78,7 +78,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: variables
-  namespace: rancher-turtles-system
+  namespace: cattle-turtles-system
 type: Opaque
 stringData:
   CLUSTER_TOPOLOGY: "true"

--- a/docs/next/modules/en/pages/reference/clusterctlconfig.adoc
+++ b/docs/next/modules/en/pages/reference/clusterctlconfig.adoc
@@ -22,7 +22,7 @@ apiVersion: turtles-capi.cattle.io/v1alpha1
 kind: ClusterctlConfig
 metadata:
   name: clusterctl-config
-  namespace: rancher-turtles-system
+  namespace: cattle-turtles-system
 spec:
   providers:
   - name: metal3
@@ -68,7 +68,7 @@ apiVersion: turtles-capi.cattle.io/v1alpha1
 kind: ClusterctlConfig
 metadata:
   name: clusterctl-config
-  namespace: rancher-turtles-system
+  namespace: cattle-turtles-system
 spec:
   providers:
   - name: rke2

--- a/docs/next/modules/en/pages/troubleshooting/troubleshooting.adoc
+++ b/docs/next/modules/en/pages/troubleshooting/troubleshooting.adoc
@@ -26,15 +26,15 @@ You can view the following pods and check their logs in namespaces:
 |===
 | Namespace | Pod | Description
 
-| rancher-turtles-system
+| cattle-turtles-system
 | rancher-turtles-cluster-api-operator
 | Manages the installation and lifecycle of Cluster API providers in the management cluster
 
-| rancher-turtles-system
+| cattle-turtles-system
 | rancher-turtles-controller-manager
 | Handles Rancher integration and manages the custom resources for Turtles
 
-| rancher-turtles-system
+| cattle-turtles-system
 | caapf-controller-manager
 | Controls the Cluster API Provider Framework for custom infrastructure providers
 
@@ -70,7 +70,7 @@ One way to monitor logs from Cluster API controll plane pods by usuing `kubectl 
 
 [source,bash]
 ----
-kubectl logs -l control-plane=controller-manager -n rancher-turtles-system -f
+kubectl logs -l control-plane=controller-manager -n cattle-turtles-system -f
 kubectl logs -l control-plane=controller-manager -n capi-system -f
 kubectl logs -l control-plane=controller-manager -n rke2-bootstrap-system -f
 kubectl logs -l control-plane=controller-manager -n rke2-control-plane-system -f
@@ -92,7 +92,7 @@ Then you can tail logs from all pods in real time.
 
 [source,bash]
 ----
-kubectl stern . -n rancher-turtles-system -n rke2-bootstrap-system -n rke2-control-plane-system -n capi-system
+kubectl stern . -n cattle-turtles-system -n rke2-bootstrap-system -n rke2-control-plane-system -n capi-system
 ----
 
 or
@@ -222,7 +222,7 @@ For example:
 [source,bash]
 ----
 helm upgrade rancher-turtles turtles/rancher-turtles \
-            -n rancher-turtles-system \
+            -n cattle-turtles-system \
             --reuse-values \
             --set "rancherTurtles.managerArguments={--insecure-skip-verify,-v=5}" \
             --set cluster-api-operator.logLevel=5
@@ -272,7 +272,7 @@ Usage via regular flags:
 
 [source,bash]
 ----
-kubectl crust-gather collect --include-namespace rancher-turtles-system --include-namespace capi-* --include-namespace cattle* --include-namespace c-* --include-namespace=<any-capi-cluster-namespace> --kubeconfig=<KUBECONFIG>
+kubectl crust-gather collect --include-namespace cattle-turtles-system --include-namespace capi-* --include-namespace cattle* --include-namespace c-* --include-namespace=<any-capi-cluster-namespace> --kubeconfig=<KUBECONFIG>
 ----
 
 You can specify a file with secrets or environment variables with secrets strings to exclude. 
@@ -329,7 +329,7 @@ Replace `capi-clusters` with the namespace where your clusters are deployed and 
 +
 [source,bash]
 ----
-helm uninstall -n rancher-turtles-system rancher-turtles
+helm uninstall -n cattle-turtles-system rancher-turtles
 ----
 +
 . Remove any webhook configurations that might have been created by CAPI providers:
@@ -351,7 +351,7 @@ kubectl delete mutatingwebhookconfigurations [webhook-name]
 ----
 +
 . Clean up any leftover namespaces and resources. The following namespaces may remain after uninstallation:
-   * rancher-turtles-system
+   * cattle-turtles-system
    * rke2-bootstrap-system
    * rke2-control-plane-system
    * capi-system
@@ -363,12 +363,12 @@ To remove these namespaces:
 [source,bash]
 ----
 # First remove any finalizers that might be blocking deletion
-for NS in rancher-turtles-system rke2-bootstrap-system rke2-control-plane-system capi-system capz-system capi-clusters; do
+for NS in cattle-turtles-system rke2-bootstrap-system rke2-control-plane-system capi-system capz-system capi-clusters; do
   kubectl get namespace $NS -o json | jq '.spec.finalizers = []' | kubectl replace --raw "/api/v1/namespaces/$NS/finalize" -f -
 done
 
 # Then delete the namespaces
-kubectl delete namespace rancher-turtles-system rke2-bootstrap-system rke2-control-plane-system capi-system capz-system capi-clusters
+kubectl delete namespace cattle-turtles-system rke2-bootstrap-system rke2-control-plane-system capi-system capz-system capi-clusters
 ----
 +
 . Finally, remove the CRDs related to Cluster API and Rancher Turtles:

--- a/docs/next/modules/en/pages/tutorials/quickstart.adoc
+++ b/docs/next/modules/en/pages/tutorials/quickstart.adoc
@@ -96,8 +96,8 @@ This will use the default values for the Helm chart, which are good for most ins
 The installation may take a few minutes and, when it finishes, you will be able to see the following new deployments in the cluster:
 
 * `capi-system/capi-controller-manager`
-* `rancher-turtles-system/caapf-controller-manager`
-* `rancher-turtles-system/rancher-turtles-controller-manager`
+* `cattle-turtles-system/caapf-controller-manager`
+* `cattle-turtles-system/rancher-turtles-controller-manager`
 * `rke2-bootstrap-system/rke2-bootstrap-controller-manager`
 * `rke2-control-plane-system/rke2-control-plane-controller-manager`
 

--- a/docs/next/modules/en/pages/tutorials/uninstall.adoc
+++ b/docs/next/modules/en/pages/tutorials/uninstall.adoc
@@ -5,7 +5,7 @@ To uninstall {product_name} use the following Helm command:
 
 [source,bash]
 ----
-helm uninstall -n rancher-turtles-system rancher-turtles --cascade foreground --wait
+helm uninstall -n cattle-turtles-system rancher-turtles --cascade foreground --wait
 ----
 
 This may take a few minutes to complete.


### PR DESCRIPTION
This PR updates `docs/next` to use `cattle-turtles-system` as the ns that Turtles uses. Follow up from https://github.com/rancher/turtles/pull/1818.