### PR TITLE
doc: Add 1.33 WatchList feature gate warning for CAAPF

### DIFF
--- a/docs/next/modules/en/pages/user/caapf.adoc
+++ b/docs/next/modules/en/pages/user/caapf.adoc
@@ -9,6 +9,11 @@ Cluster API Add-on Provider for `Fleet` (CAAPF) is a Cluster API (CAPI) provider
 For more information about the provider, please refer to https://rancher.github.io/cluster-api-addon-provider-fleet/[CAAPF book].
 ====
 
+[WARNING]
+====
+CAAPF depends on the `WatchList` Kubernetes feature gate. This feature needs to be explicitly enabled on Kubernetes `1.33` versions. See link:https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/[docs].
+====
+
 == Functionality
 
 * The provider will register a newly provisioned CAPI cluster with `Fleet` by creating a `Fleet` `Cluster` instance with the same `name` and `namespace`. Applications can be automatically deployed to the created cluster using `GitOps`.

--- a/docs/next/modules/en/pages/user/clusterclass.adoc
+++ b/docs/next/modules/en/pages/user/clusterclass.adoc
@@ -421,6 +421,11 @@ In order to migrate to Rancher `v2.12` and `HelmOps`, you need to take the follo
 Following these steps is necessary to guarantee the downstream Clusters will not be affected during the `HelmApp` conversion.  
 ====
 
+[WARNING]
+====
+Examples using the Fleet Add-on Provider CAAPF depend on the `WatchList` Kubernetes feature gate. This feature needs to be explicitly enabled on Kubernetes `1.33` versions. See link:https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/[docs].
+====
+
 [tabs]
 ======
 

--- a/docs/v0.24/modules/en/pages/user/caapf.adoc
+++ b/docs/v0.24/modules/en/pages/user/caapf.adoc
@@ -9,6 +9,11 @@ Cluster API Add-on Provider for `Fleet` (CAAPF) is a Cluster API (CAPI) provider
 For more information about the provider, please refer to https://rancher.github.io/cluster-api-addon-provider-fleet/[CAAPF book].
 ====
 
+[WARNING]
+====
+CAAPF depends on the `WatchList` Kubernetes feature gate. This feature needs to be explicitly enabled on Kubernetes `1.33` versions. See link:https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/[docs].
+====
+
 == Functionality
 
 * The provider will register a newly provisioned CAPI cluster with `Fleet` by creating a `Fleet` `Cluster` instance with the same `name` and `namespace`. Applications can be automatically deployed to the created cluster using `GitOps`.

--- a/docs/v0.24/modules/en/pages/user/clusterclass.adoc
+++ b/docs/v0.24/modules/en/pages/user/clusterclass.adoc
@@ -421,6 +421,11 @@ In order to migrate to Rancher `v2.12` and `HelmOps`, you need to take the follo
 Following these steps is necessary to guarantee the downstream Clusters will not be affected during the `HelmApp` conversion.  
 ====
 
+[WARNING]
+====
+Examples using the Fleet Add-on Provider CAAPF depend on the `WatchList` Kubernetes feature gate. This feature needs to be explicitly enabled on Kubernetes `1.33` versions. See link:https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/[docs].
+====
+
 [tabs]
 ======
 


### PR DESCRIPTION
This feature has been defaulted to false in 1.33. 
This should provide some help for users affected by the change.